### PR TITLE
Update htop version to 3.5.1 for upstream synchronization

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,5 +1,5 @@
 # bump: htop-version /HTOP_VERSION="(.*)"/ https://github.com/htop-dev/htop.git|semver:*
-HTOP_VERSION="3.4.1"
+HTOP_VERSION="3.5.1"
 
 export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_CATEGORIES="utilities"


### PR DESCRIPTION
### Purpose
Updates the htop build environment configuration to track the stable upstream 3.5.1 release sequence. This addresses upstream synchronization by aligning the environment with current stable releases.

### Changes
* **`buildenv`**: Updated `HTOP_VERSION` from `"3.4.1"` to `"3.5.1"` to align with the file's declared semver tracking behavior.

### Verification & Stability
* Verified that upstream version `3.5.1` is a fully tagged, stable release from `htop-dev/htop`.
* Confirmed local configuration tracking parses cleanly in Windows Subsystem for Linux (WSL).

### Maintainer Note
As a new contributor to the zopen ecosystem, I wanted to submit this bump to help align the project with current upstream releases. Please let me know if this matches current release priorities or if any accompanying adjustments are needed for the build pipeline!